### PR TITLE
Enhance GitHub Path Handling and Improve Test Coverage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'fsspec',
+        'requests',
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,13 @@ setup(
     name='repo_crawler',
     version='0.1.0',
     description='A lightweight Python tool to crawl directories or GitHub repositories and print file contents with line numbers, with support for file exclusion.',
-    author='Your Name',
+    author='Repo Crawler',
     author_email='repo-crawler@googlegroups.com',
     url='https://github.com/repo-crawler/repo-crawler',
     packages=find_packages(),
     install_requires=[
-        'fsspec',
-        'requests',
+        'fsspec>=2025,<2026',
+        'requests>=2,<3',   
     ],
     entry_points={
         'console_scripts': [

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,6 +1,85 @@
-import pytest
+import unittest
+from unittest.mock import patch
+import io
+import sys
+
 from repo_crawler.crawl import crawl_repo_files
 
-def test_invalid_github_path():
-    with pytest.raises(ValueError):
-        crawl_repo_files("not_github://invalid")
+class FakeFS:
+    """
+    A fake filesystem to simulate fsspec behavior for unit tests.
+    """
+    def __init__(self, files):
+        """
+        :param files: A dict mapping file paths to a tuple (content, info_dict).
+                      Example:
+                          {
+                              "github://user/repo/branch/file1.txt": ("hello\nworld\n", {'type': 'file'}),
+                              "github://user/repo/branch/file2.svg": ("should be excluded", {'type': 'file'}),
+                              "github://user/repo/branch/dir": ("", {'type': 'directory'}),
+                          }
+        """
+        self.files = files
+
+    def glob(self, pattern, recursive=False):
+        # For testing, we ignore the pattern and return all known paths.
+        return list(self.files.keys())
+
+    def info(self, path):
+        if path in self.files:
+            return self.files[path][1]
+        raise FileNotFoundError(f"No such file: {path}")
+
+    def open(self, path, mode='r'):
+        if path in self.files:
+            content = self.files[path][0]
+            return io.StringIO(content)
+        raise FileNotFoundError(f"No such file: {path}")
+
+class TestCrawl(unittest.TestCase):
+    def test_invalid_path(self):
+        """Test that a non-GitHub URL (missing 'github://') raises a ValueError."""
+        with self.assertRaises(ValueError):
+            crawl_repo_files("repo-crawler/repo-crawler")
+
+    @patch("repo_crawler.crawl.fsspec.filesystem")
+    def test_valid_path_with_exclusion(self, mock_filesystem):
+        """
+        Test that crawl_repo_files correctly prints file contents (with headers and line numbers)
+        for valid files and excludes files with extensions listed in exclude_exts.
+        """
+        # Prepare a fake filesystem with:
+        # - a valid text file,
+        # - a file with an excluded extension,
+        # - and a directory (which should be skipped).
+        fake_files = {
+            "github://user/repo/branch/file1.txt": ("hello\nworld\n", {'type': 'file'}),
+            "github://user/repo/branch/file2.svg": ("should be excluded", {'type': 'file'}),
+            "github://user/repo/branch/dir": ("", {'type': 'directory'}),
+        }
+        fake_fs = FakeFS(fake_files)
+        mock_filesystem.return_value = fake_fs
+
+        # Capture printed output
+        captured_output = io.StringIO()
+        original_stdout = sys.stdout
+        sys.stdout = captured_output
+
+        try:
+            # Call the function with an exclusion for '.svg' files.
+            crawl_repo_files("github://user/repo/branch", exclude_exts=['svg'])
+            output = captured_output.getvalue()
+        finally:
+            sys.stdout = original_stdout
+
+        # Check that file1.txt header and content were printed with line numbers.
+        self.assertIn("# github://user/repo/branch/file1.txt", output)
+        self.assertIn("1| hello", output)
+        self.assertIn("2| world", output)
+
+        # Ensure that file2.svg (and its content) is not printed.
+        self.assertNotIn("file2.svg", output)
+        self.assertNotIn("should be excluded", output)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -7,7 +7,7 @@ from repo_crawler.crawl import crawl_repo_files
 
 class FakeFS:
     """
-    A fake filesystem to simulate fsspec behavior for unit tests.
+    A fake filesystem to simulate fsspec's GitHub filesystem for testing.
     """
     def __init__(self, files):
         """
@@ -20,9 +20,11 @@ class FakeFS:
                           }
         """
         self.files = files
+        self.last_glob = None  # Record the last glob pattern passed
 
     def glob(self, pattern, recursive=False):
-        # For testing, we ignore the pattern and return all known paths.
+        self.last_glob = pattern
+        # For testing, return all known paths regardless of the pattern.
         return list(self.files.keys())
 
     def info(self, path):
@@ -37,21 +39,31 @@ class FakeFS:
         raise FileNotFoundError(f"No such file: {path}")
 
 class TestCrawl(unittest.TestCase):
-    def test_invalid_path(self):
-        """Test that a non-GitHub URL (missing 'github://') raises a ValueError."""
-        with self.assertRaises(ValueError):
-            crawl_repo_files("repo-crawler/repo-crawler")
+    @patch("repo_crawler.crawl.fsspec.filesystem")
+    def test_path_transformation(self, mock_filesystem):
+        """
+        Test that an input in the form "org/name" (without a prefix)
+        is transformed to "github://org/name/main" (default branch 'main')
+        and that the glob pattern is correctly constructed.
+        """
+        fake_fs = FakeFS({})
+        mock_filesystem.return_value = fake_fs
+
+        # Call with an input missing the 'github://' prefix.
+        crawl_repo_files("repo-crawler/repo-crawler")
+
+        # Check that the function constructed the correct glob pattern.
+        expected_pattern = "github://repo-crawler/repo-crawler/main/**"
+        self.assertEqual(fake_fs.last_glob, expected_pattern)
 
     @patch("repo_crawler.crawl.fsspec.filesystem")
     def test_valid_path_with_exclusion(self, mock_filesystem):
         """
-        Test that crawl_repo_files correctly prints file contents (with headers and line numbers)
-        for valid files and excludes files with extensions listed in exclude_exts.
+        Test that crawl_repo_files prints file contents with headers and line numbers
+        for valid files, and that files with excluded extensions are skipped.
         """
-        # Prepare a fake filesystem with:
-        # - a valid text file,
-        # - a file with an excluded extension,
-        # - and a directory (which should be skipped).
+        # Setup fake files: one valid text file, one file with an excluded extension,
+        # and one directory (which should be ignored).
         fake_files = {
             "github://user/repo/branch/file1.txt": ("hello\nworld\n", {'type': 'file'}),
             "github://user/repo/branch/file2.svg": ("should be excluded", {'type': 'file'}),
@@ -60,24 +72,23 @@ class TestCrawl(unittest.TestCase):
         fake_fs = FakeFS(fake_files)
         mock_filesystem.return_value = fake_fs
 
-        # Capture printed output
+        # Capture printed output.
         captured_output = io.StringIO()
         original_stdout = sys.stdout
         sys.stdout = captured_output
 
         try:
-            # Call the function with an exclusion for '.svg' files.
             crawl_repo_files("github://user/repo/branch", exclude_exts=['svg'])
             output = captured_output.getvalue()
         finally:
             sys.stdout = original_stdout
 
-        # Check that file1.txt header and content were printed with line numbers.
+        # Check that file1.txt header and its contents (with line numbers) are present.
         self.assertIn("# github://user/repo/branch/file1.txt", output)
         self.assertIn("1| hello", output)
         self.assertIn("2| world", output)
 
-        # Ensure that file2.svg (and its content) is not printed.
+        # Ensure that file2.svg and its contents are not printed.
         self.assertNotIn("file2.svg", output)
         self.assertNotIn("should be excluded", output)
 


### PR DESCRIPTION
This update enhances `repo_crawler` by improving GitHub path handling, refining file exclusion logic, and expanding test coverage.  

### Key Changes:  
- **GitHub Path Handling:**  
  - Now supports paths in the format `org/name:branch` or `org/name` (defaults to `main` branch).  
  - Automatically converts these formats to `github://org/name/branch`.  

- **Code Enhancements:**  
  - Streamlined GitHub filesystem initialization.  
  - Improved file type checks and exclusion logic.  

- **Dependency Updates:**  
  - Updated `fsspec` requirement to `>=2025,<2026`.  
  - Added `requests` dependency (`>=2,<3`).  

- **Test Improvements:**  
  - Replaced `pytest` with `unittest` for better control.  
  - Introduced `FakeFS` mock class to simulate GitHub filesystem behavior.  
  - Added tests for path transformation and exclusion logic.  

These improvements ensure better usability, robustness, and maintainability. 🚀