### PR TITLE
Enforce Username Requirement When Using Token

### DIFF
--- a/repo_crawler/crawl.py
+++ b/repo_crawler/crawl.py
@@ -102,6 +102,10 @@ def main():
     )
     args = parser.parse_args()
 
+    # Enforce that if a token is provided, a username must be provided.
+    if args.token and not args.username:
+        parser.error("When using --token, you must also provide --username.")
+
     crawl_repo_files(args.github_path, exclude_exts=args.exclude, token=args.token, username=args.username)
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updated `crawl.py` to ensure that if a GitHub token is provided, a username must also be specified. This prevents authentication issues when accessing private repositories.