### PR TITLE
Refactor Repo Crawler Tests to Use Pytest  

### DIFF
--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -1,7 +1,6 @@
-import unittest
+import pytest
 from unittest.mock import patch
 import io
-import sys
 
 from repo_crawler.crawl import crawl_repo_files
 
@@ -38,63 +37,61 @@ class FakeFS:
             return io.StringIO(content)
         raise FileNotFoundError(f"No such file: {path}")
 
-class TestCrawl(unittest.TestCase):
-    @patch("repo_crawler.crawl.fsspec.filesystem")
-    def test_path_transformation(self, mock_filesystem):
-        """
-        Test that an input in the form "org/name" (without a prefix)
-        is transformed properly and that the glob pattern is correctly constructed.
-        Since the GitHub filesystem is initialized with org, repo, and ref,
-        the glob pattern is relative to the repository root.
-        """
-        fake_fs = FakeFS({})
-        mock_filesystem.return_value = fake_fs
+@pytest.fixture
+def fake_fs():
+    """Fixture providing an empty FakeFS instance."""
+    return FakeFS({})
 
-        # Call with an input missing the 'github://' prefix.
-        crawl_repo_files("repo-crawler/repo-crawler")
+@pytest.fixture
+def fake_fs_with_files():
+    """Fixture providing a FakeFS instance with test files."""
+    files = {
+        "github://user/repo/branch/file1.txt": ("hello\nworld\n", {'type': 'file'}),
+        "github://user/repo/branch/file2.svg": ("should be excluded", {'type': 'file'}),
+        "github://user/repo/branch/dir": ("", {'type': 'directory'}),
+    }
+    return FakeFS(files)
 
-        # With no subdirectory provided, the glob pattern should be just "**"
-        expected_pattern = "**"
-        self.assertEqual(fake_fs.last_glob, expected_pattern)
+@patch("repo_crawler.crawl.fsspec.filesystem")
+def test_path_transformation(mock_filesystem, fake_fs):
+    """
+    Test that an input in the form "org/name" (without a prefix)
+    is transformed properly and that the glob pattern is correctly constructed.
+    Since the GitHub filesystem is initialized with org, repo, and ref,
+    the glob pattern is relative to the repository root.
+    """
+    mock_filesystem.return_value = fake_fs
 
-    @patch("repo_crawler.crawl.fsspec.filesystem")
-    def test_valid_path_with_exclusion(self, mock_filesystem):
-        """
-        Test that crawl_repo_files prints file contents with headers and line numbers
-        for valid files, and that files with excluded extensions are skipped.
-        """
-        # Setup fake files: one valid text file, one file with an excluded extension,
-        # and one directory (which should be ignored).
-        fake_files = {
-            "github://user/repo/branch/file1.txt": ("hello\nworld\n", {'type': 'file'}),
-            "github://user/repo/branch/file2.svg": ("should be excluded", {'type': 'file'}),
-            "github://user/repo/branch/dir": ("", {'type': 'directory'}),
-        }
-        fake_fs = FakeFS(fake_files)
-        mock_filesystem.return_value = fake_fs
+    # Call with an input missing the 'github://' prefix
+    crawl_repo_files("repo-crawler/repo-crawler")
 
-        # Capture printed output.
-        captured_output = io.StringIO()
-        original_stdout = sys.stdout
-        sys.stdout = captured_output
+    # With no subdirectory provided, the glob pattern should be just "**"
+    expected_pattern = "**"
+    assert fake_fs.last_glob == expected_pattern
 
-        try:
-            crawl_repo_files("github://user/repo/branch", exclude_exts=['svg'])
-            output = captured_output.getvalue()
-        finally:
-            sys.stdout = original_stdout
+@patch("repo_crawler.crawl.fsspec.filesystem")
+def test_valid_path_with_exclusion(mock_filesystem, fake_fs_with_files, capsys):
+    """
+    Test that crawl_repo_files prints file contents with headers and line numbers
+    for valid files, and that files with excluded extensions are skipped.
+    """
+    mock_filesystem.return_value = fake_fs_with_files
 
-        # Check that file1.txt header and its contents (with padded line numbers) are present.
-        self.assertIn("# github://user/repo/branch/file1.txt", output)
-        self.assertIn("00001| hello", output)
-        self.assertIn("00002| world", output)
+    # Call the function with svg files excluded
+    crawl_repo_files("github://user/repo/branch", exclude_exts=['svg'])
+    
+    # Capture the output using pytest's built-in capture
+    captured = capsys.readouterr()
+    output = captured.out
 
-        # Ensure that file2.svg and its contents are not printed.
-        self.assertNotIn("file2.svg", output)
-        self.assertNotIn("should be excluded", output)
+    # Check that file1.txt header and its contents (with padded line numbers) are present
+    assert "# github://user/repo/branch/file1.txt" in output
+    assert "00001| hello" in output
+    assert "00002| world" in output
 
-        # Ensure there is a blank line after the file content.
-        self.assertRegex(output, r"world\n\n")
+    # Ensure that file2.svg and its contents are not printed
+    assert "file2.svg" not in output
+    assert "should be excluded" not in output
 
-if __name__ == '__main__':
-    unittest.main()
+    # Ensure there is a blank line after the file content
+    assert "world\n\n" in output


### PR DESCRIPTION
Updated `test_crawl.py` to replace `unittest` with `pytest`, improving test readability and maintainability. Introduced fixtures for mock file systems and used `capsys` for output capture.