### PR TITLE
Enhance Repo Crawler: Case-Insensitive Exclusions, Output Flexibility, and Improved Validation

### DIFF
--- a/repo_crawler/crawl.py
+++ b/repo_crawler/crawl.py
@@ -8,14 +8,14 @@ from pathlib import Path
 def crawl_repo_files(github_path, exclude_exts=None, token=None, username=None, out=None):
     """
     Recursively crawls a GitHub repository using fsspec's GitHubFileSystem,
-    printing each file's content with a header and numbered lines.
+    printing each file's content with a header and numbered lines, or a running count if writing to a file.
 
     The github_path can be provided in one of the following formats:
       1. github://<org>/<repo>/<branch>[/optional/path]
       2. <org>/<repo>:<branch> or <org>/<repo> (branch defaults to "main" if omitted)
 
     :param github_path: The GitHub repository path.
-    :param exclude_exts: A list of file extensions to exclude (e.g., ['svg']).
+    :param exclude_exts: A list of file extensions to exclude (e.g., ['svg', 'jpg']).
     :param token: Optional GitHub token for accessing private repositories.
     :param username: Optional GitHub username for accessing private repositories.
     :param out: A file-like object to write the output to (default: sys.stdout).
@@ -46,11 +46,11 @@ def crawl_repo_files(github_path, exclude_exts=None, token=None, username=None, 
     # Initialize the GitHub filesystem with the required parameters.
     fs = fsspec.filesystem("github", org=org, repo=repo, ref=ref, token=token, username=username)
 
-    # Construct the glob pattern. Note: The GitHubFileSystem works with paths
-    # relative to the repository root, so we use the subdir if provided.
+    # Construct the glob pattern. The GitHubFileSystem works with paths relative to the repository root.
     pattern = f"{subdir}/**" if subdir else "**"
     all_paths = fs.glob(pattern, recursive=True)
 
+    file_count = 0
     for path in all_paths:
         try:
             info = fs.info(path)
@@ -62,25 +62,31 @@ def crawl_repo_files(github_path, exclude_exts=None, token=None, username=None, 
         if info.get('type') != 'file':
             continue
 
-        # Check file extension against exclusions.
+        # Check file extension against exclusions (case-insensitive)
         if exclude_exts:
             parts_split = path.rsplit('.', 1)
-            if len(parts_split) == 2 and parts_split[1] in exclude_exts:
-                continue
+            if len(parts_split) == 2:
+                ext = parts_split[1].lower()
+                if ext in [e.lower() for e in exclude_exts]:
+                    continue
 
-        # Print header with file path.
-        print(f'# {path}', file=out)
+        file_count += 1
 
-        # Open and print file contents with line numbers.
-        try:
-            with fs.open(path, 'r') as f:
-                for i, line in enumerate(f, start=1):
-                    # Pad the line number to 5 digits.
-                    print(f'{i:05d}| {line}', end='', file=out)
-            # Insert a blank line between files.
-            print(file=out)
-        except Exception as e:
-            print(f"Error reading {path}: {e}", file=out)
+        # If output is not sys.stdout, print only the running count.
+        if out != sys.stdout:
+            print(f"{file_count}", file=out)
+        else:
+            # Otherwise, print full output with header and line-numbered content.
+            print(f'# {path}', file=out)
+            try:
+                with fs.open(path, 'r') as f:
+                    for i, line in enumerate(f, start=1):
+                        # Pad the line number to 5 digits.
+                        print(f'{i:05d}| {line}', end='', file=out)
+                # Insert a blank line between files.
+                print(file=out)
+            except Exception as e:
+                print(f"Error reading {path}: {e}", file=out)
 
 def main():
     parser = argparse.ArgumentParser(
@@ -96,7 +102,7 @@ def main():
         "--exclude",
         nargs='*',
         default=[],
-        help="List of file extensions to exclude (e.g., svg)"
+        help="List of file extensions to exclude (e.g., svg jpg png)"
     )
     parser.add_argument(
         "--token",
@@ -109,15 +115,18 @@ def main():
         default=None
     )
     parser.add_argument(
-        "--output",
+        "--out", "--output",
+        dest="output",
         help=("Optional full output file path to write the scan results. "
-              "The path must be an absolute path to a file (not a directory) and include a file extension."),
+              "If specified, the file will contain a running count (one number per file processed) "
+              "instead of the full file contents. The path must be an absolute path to a file (not a directory) and include a file extension."),
         default=None
     )
     args = parser.parse_args()
 
-    # Set up basic logging configuration.
-    logging.basicConfig(level=logging.INFO)
+    # Enforce that if a token is provided, a username must be provided.
+    if args.token and not args.username:
+        parser.error("When using --token, you must also provide --username.")
 
     if args.output:
         output_path = args.output
@@ -125,10 +134,8 @@ def main():
         # Validate that the output path is a full absolute path.
         if not os.path.isabs(output_path):
             raise ValueError("Output path must be a full absolute path.")
-        # Ensure the output path does not end with a path separator (i.e. is not a directory).
         if output_path.endswith(os.sep):
             raise ValueError("Output path must be a file, not a directory.")
-        # Check that the basename has an extension.
         if not os.path.splitext(os.path.basename(output_path))[1]:
             raise ValueError("Output file must have an extension.")
 
@@ -149,12 +156,6 @@ def main():
             crawl_repo_files(args.github_path, exclude_exts=args.exclude, token=args.token, username=args.username, out=out_file)
     else:
         crawl_repo_files(args.github_path, exclude_exts=args.exclude, token=args.token, username=args.username)
-
-    # Enforce that if a token is provided, a username must be provided.
-    if args.token and not args.username:
-        parser.error("When using --token, you must also provide --username.")
-
-    crawl_repo_files(args.github_path, exclude_exts=args.exclude, token=args.token, username=args.username)
 
 if __name__ == "__main__":
     main()

--- a/repo_crawler/crawl.py
+++ b/repo_crawler/crawl.py
@@ -8,7 +8,8 @@ from pathlib import Path
 def crawl_repo_files(github_path, exclude_exts=None, token=None, username=None, out=None):
     """
     Recursively crawls a GitHub repository using fsspec's GitHubFileSystem,
-    printing each file's content with a header and numbered lines, or a running count if writing to a file.
+    printing each file's content with a header and numbered lines, or the file's
+    name if writing to a file.
 
     The github_path can be provided in one of the following formats:
       1. github://<org>/<repo>/<branch>[/optional/path]
@@ -50,7 +51,6 @@ def crawl_repo_files(github_path, exclude_exts=None, token=None, username=None, 
     pattern = f"{subdir}/**" if subdir else "**"
     all_paths = fs.glob(pattern, recursive=True)
 
-    file_count = 0
     for path in all_paths:
         try:
             info = fs.info(path)
@@ -70,11 +70,9 @@ def crawl_repo_files(github_path, exclude_exts=None, token=None, username=None, 
                 if ext in [e.lower() for e in exclude_exts]:
                     continue
 
-        file_count += 1
-
-        # If output is not sys.stdout, print only the running count.
+        # If output is not sys.stdout, print the file name.
         if out != sys.stdout:
-            print(f"{file_count}", file=out)
+            print(path, file=out)
         else:
             # Otherwise, print full output with header and line-numbered content.
             print(f'# {path}', file=out)
@@ -118,7 +116,7 @@ def main():
         "--out", "--output",
         dest="output",
         help=("Optional full output file path to write the scan results. "
-              "If specified, the file will contain a running count (one number per file processed) "
+              "If specified, the file will contain the name of each file processed "
               "instead of the full file contents. The path must be an absolute path to a file (not a directory) and include a file extension."),
         default=None
     )


### PR DESCRIPTION
This PR introduces several improvements and refinements to the GitHub repository crawler:

- **Case-Insensitive File Exclusion:**  
  File extension exclusions are now handled in a case-insensitive manner. This ensures that files like `example.JPG` or `example.jpg` are both correctly excluded when specified.

- **Output Handling Enhancements:**  
  - When writing to a file (i.e., when the output stream is not `sys.stdout`), only the file names are printed.
  - When outputting to `sys.stdout`, the crawler prints each file's content with a header and numbered lines.
  - The help text for the output argument has been updated to clearly indicate this behavior.

- **Improved Command-Line Argument Parsing:**  
  - The output parameter now supports both `--out` and `--output` flags.
  - Added a validation to ensure that if a GitHub token is provided, a username must also be supplied, preventing authentication issues.

- **Documentation and Code Style Updates:**  
  - The docstrings have been updated to reflect the new behavior for output handling and file extension exclusions.
  - Minor refactoring has been done to simplify the glob pattern construction and remove duplicate logic.

These changes aim to enhance usability and reliability, making the crawler more adaptable to different use cases and output requirements.