### PR TITLE
Handle invalid branch errors in `crawl_repo_files` and add test coverage

### DIFF
--- a/repo_crawler/crawl.py
+++ b/repo_crawler/crawl.py
@@ -49,7 +49,13 @@ def crawl_repo_files(github_path, include_exts=None, exclude_exts=None, token=No
 
     # Build the glob pattern for recursive search
     pattern = f"{subdir}/**" if subdir else "**"
-    all_paths = fs.glob(pattern, recursive=True)
+    try:
+        all_paths = fs.glob(pattern, recursive=True)
+    except Exception as e:
+        raise ValueError(
+            f"Failed to access branch '{ref}' in repository '{org}/{repo}'. "
+            "Please verify that the branch exists."
+        ) from e
 
     for path in all_paths:
         try:

--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -106,3 +106,21 @@ def test_include_exclude_mutual_exclusivity(monkeypatch):
     monkeypatch.setattr(sys, "argv", test_args)
     with pytest.raises(SystemExit):
         main()
+
+@patch("repo_crawler.crawl.fsspec.filesystem")
+def test_invalid_branch_error(mock_filesystem, fake_fs):
+    """
+    Test that a ValueError with an appropriate message is raised
+    when fs.glob fails due to an invalid branch.
+    """
+    # Simulate an error when attempting to glob (e.g., due to an invalid branch)
+    def glob_raise(pattern, recursive):
+        raise Exception("Simulated error: branch not found")
+    fake_fs.glob = glob_raise
+    mock_filesystem.return_value = fake_fs
+
+    # Using a repository path with an invalid branch
+    invalid_path = "github://user/repo/invalidbranch"
+
+    with pytest.raises(ValueError, match=r"Failed to access branch 'invalidbranch' in repository 'user/repo'"):
+        crawl_repo_files(invalid_path)


### PR DESCRIPTION
This PR improves error handling in `crawl_repo_files` by catching exceptions raised when attempting to list repository files using `fs.glob`. If the specified branch does not exist, a `ValueError` is now raised with a clear message indicating the issue.

#### Changes
- Wrapped `fs.glob` in a `try-except` block to catch exceptions and raise a `ValueError` with a more descriptive error message.
- Added a unit test (`test_invalid_branch_error`) to verify that a `ValueError` is raised when an invalid branch is specified.
- Mocked `fsspec.filesystem` in the test to simulate the error scenario.

#### Why?
Previously, if `fs.glob` failed due to an invalid branch, the error message was unclear. This update ensures better error reporting and test coverage.

#### Testing
- Added a new test case that simulates a failed `fs.glob` call and checks that the correct `ValueError` is raised.
- Existing tests remain unchanged and pass.

This should improve the robustness and usability of the repository crawler. 🚀