### PR TITLE
Enhance branch validation and error handling in repo crawler  

### DIFF
--- a/tests/test_crawl.py
+++ b/tests/test_crawl.py
@@ -107,20 +107,12 @@ def test_include_exclude_mutual_exclusivity(monkeypatch):
     with pytest.raises(SystemExit):
         main()
 
-@patch("repo_crawler.crawl.fsspec.filesystem")
-def test_invalid_branch_error(mock_filesystem, fake_fs):
+@patch("repo_crawler.crawl.verify_branch_exists", side_effect=ValueError("Branch 'invalidbranch' does not exist in repository 'user/repo'."))
+def test_invalid_branch_error(mock_verify):
     """
     Test that a ValueError with an appropriate message is raised
-    when fs.glob fails due to an invalid branch.
+    when the branch verification fails due to an invalid branch.
     """
-    # Simulate an error when attempting to glob (e.g., due to an invalid branch)
-    def glob_raise(pattern, recursive):
-        raise Exception("Simulated error: branch not found")
-    fake_fs.glob = glob_raise
-    mock_filesystem.return_value = fake_fs
-
-    # Using a repository path with an invalid branch
     invalid_path = "github://user/repo/invalidbranch"
-
-    with pytest.raises(ValueError, match=r"Failed to access branch 'invalidbranch' in repository 'user/repo'"):
+    with pytest.raises(ValueError, match=r"Branch 'invalidbranch' does not exist in repository 'user/repo'."):
         crawl_repo_files(invalid_path)


### PR DESCRIPTION
This update improves branch validation in the `repo_crawler` module by introducing a `verify_branch_exists` function. This function queries the GitHub API to confirm that the specified branch exists before attempting to crawl repository files.  

### Key Changes:  
- Added `verify_branch_exists`, which raises an error if a branch is missing.  
- Integrated branch verification into `crawl_repo_files` before initializing the filesystem.  
- Improved error handling when no files are found, treating an empty branch as a possible cause.  
- Updated unit tests:  
  - Patched `verify_branch_exists` in tests to prevent real API calls.  
  - Refactored `test_invalid_branch_error` to check for API-based validation instead of filesystem failures.  
  - Adjusted tests to ensure `fake_fs_with_files` properly mimics file presence.  
  - Removed the unused `fake_fs` fixture.  

These improvements enhance robustness by preventing unnecessary operations on non-existent branches and improving test reliability.