### PR TITLE
Fix branch reference in `GithubFileSystem` initialization  

### DIFF
--- a/repo_crawler/crawl.py
+++ b/repo_crawler/crawl.py
@@ -63,7 +63,7 @@ def crawl_repo_files(github_path, include_exts=None, exclude_exts=None, token=No
     # Verify that the specified branch actually exists.
     verify_branch_exists(org, repo, ref, token)
 
-    fs = GithubFileSystem(org=org, repo=repo, ref=ref, token=token, username=username)
+    fs = GithubFileSystem(org=org, repo=repo, sha=ref, token=token, username=username)
 
     # Build the glob pattern for recursive search.
     pattern = f"{subdir}/**" if subdir else "**"


### PR DESCRIPTION
This PR updates the `GithubFileSystem` initialization in `crawl.py` to use `sha=ref` instead of `ref`. This change ensures that the correct commit SHA is used, preventing potential issues when referencing branches.  

#### Changes:  
- Modified `GithubFileSystem` instantiation to use `sha=ref` instead of `ref`.  

#### Why?  
The `GithubFileSystem` expects a SHA for precise repository navigation. Using `ref` could lead to incorrect behavior if the value is a branch name instead of a commit SHA.  

#### Impact:  
- Ensures correct repository crawling behavior.  
- Prevents potential errors due to ambiguous branch references.  

No breaking changes expected.